### PR TITLE
allow initGitbook() to be run multiple times (i.e., after changing SUMMARY.md)

### DIFF
--- a/R/initGitbook.R
+++ b/R/initGitbook.R
@@ -16,7 +16,7 @@ initGitbook <- function(dir=getwd()) {
 	mdfiles <- list.files(dir, '*.md', recursive=TRUE, full.names=TRUE)
 	mdfiles <- mdfiles[-c(grep('README.md$', mdfiles),
 						  grep('SUMMARY.md$', mdfiles))]
-	mdfiles2 <- gsub('.md$', '.Rmd', mdfiles)
+	mdfiles2 <- gsub('/.md$', '.Rmd', mdfiles)
 	file.rename(mdfiles, mdfiles2)
 	
 	knitr.header <- c( # TODO: make a package option?

--- a/R/initGitbook.R
+++ b/R/initGitbook.R
@@ -33,7 +33,12 @@ initGitbook <- function(dir=getwd()) {
 		file <- file(rmd)
 		lines <- readLines(file)
 		close(file)
-		lines <- c(knitr.header, lines)
+		
+		#if the knitsetup block isn't already in the file, then add it
+		if(grepl("r knitsetup.+\n", lines)) {
+			lines <- c(knitr.header, lines)
+		}
+		
 		file <- file(rmd)
 		writeLines(lines, file(rmd))
 		close(file)

--- a/R/initGitbook.R
+++ b/R/initGitbook.R
@@ -35,9 +35,11 @@ initGitbook <- function(dir=getwd()) {
 		close(file)
 		
 		#if the knitsetup block isn't already in the file, then add it
-		if(grepl("r knitsetup.+\n", lines)) {
-			lines <- c(knitr.header, lines)
-		}
+		suppressWarnings(
+			if(grepl("r knitsetup.+\n", lines)) {
+				lines <- c(knitr.header, lines)
+			}
+		)
 		
 		file <- file(rmd)
 		writeLines(lines, file(rmd))


### PR DESCRIPTION
Two fixes that improve performance when running initGitbook() after changing SUMMARY.md. First, Escaping the '.' character in prevents renaming of preexisting .Rmd files.  Also, this pull request checks for existence of the knitr header before adding it: otherwise you get duplicate headers. 
