### PR TITLE
CNAME argument for publishGitbook()

### DIFF
--- a/R/publishGitbook.R
+++ b/R/publishGitbook.R
@@ -23,7 +23,7 @@ publishGitbook <- function(repo,
 	
   
   if(CNAME != ""){
-	  fileConn<-file("CNAME")
+	  fileConn<-file(paste0(out.dir,"/CNAME"))
 	  writeLines(CNAME, fileConn)
 	  close(fileConn)
 	}

--- a/R/publishGitbook.R
+++ b/R/publishGitbook.R
@@ -10,14 +10,25 @@
 #' @param repo the github repository. Should be of form username/repository
 #' @param out.dir location of the built gitbook. 
 #' @param message commit message.
+#' @param CNAME web address to be added to CNAME file on github for custom domain names
 #' 
 #' @export
 publishGitbook <- function(repo, 
 						   out.dir=paste0(getwd(), '/_book'),
-						   message='Update built gitbook') {
+						   message='Update built gitbook',
+               CNAME = ""
+               ) {
 	test <- system('git --version', ignore.stderr=TRUE, ignore.stdout=TRUE, show.output.on.console=FALSE)
 	if(test != 0) { stop('Git does not appear to be installed.')}
-	cmd <- paste0(
+	
+  
+  if(CNAME != ""){
+	  fileConn<-file("CNAME")
+	  writeLines(CNAME, fileConn)
+	  close(fileConn)
+	}
+  
+  cmd <- paste0(
 		"cd ", out.dir, " \n",
 		"git init \n",
 		"git commit --allow-empty -m '", message,"' \n",

--- a/man/publishGitbook.Rd
+++ b/man/publishGitbook.Rd
@@ -3,7 +3,7 @@
 \title{Publish the built gitbook to Github.}
 \usage{
 publishGitbook(repo, out.dir = paste0(getwd(), "/_book"),
-  message = "Update built gitbook")
+  message = "Update built gitbook", CNAME = "")
 }
 \arguments{
   \item{repo}{the github repository. Should be of form
@@ -12,6 +12,9 @@ publishGitbook(repo, out.dir = paste0(getwd(), "/_book"),
   \item{out.dir}{location of the built gitbook.}
 
   \item{message}{commit message.}
+
+  \item{CNAME}{web address to be added to CNAME file on
+  github for custom domain names}
 }
 \description{
 Note that this is a wrapper to system \code{git} call.


### PR DESCRIPTION
adds a CNAME argument, specifying the custom domain to be added to a CNAME file on github when published. 
