### PR TITLE
Update initGitbook.R

### DIFF
--- a/R/initGitbook.R
+++ b/R/initGitbook.R
@@ -8,44 +8,43 @@
 #' 
 #' @export
 initGitbook <- function(dir=getwd()) {
-	dir <- normalizePath(dir)
-	checkForGitbook(quiet=TRUE)
-	oldwd <- setwd(dir)
-	test <- system(paste0('gitbook init ', dir))
-	if(test != 0) { stop("gitbook initalization failed") }
-	mdfiles <- list.files(dir, '*.md', recursive=TRUE, full.names=TRUE)
-	mdfiles <- mdfiles[-c(grep('README.md$', mdfiles),
-						  grep('SUMMARY.md$', mdfiles))]
-	mdfiles2 <- gsub('/.md$', '.Rmd', mdfiles)
-	file.rename(mdfiles, mdfiles2)
-	
-	knitr.header <- c( # TODO: make a package option?
-		"```{r knitsetup, echo=FALSE, results='hide', warning=FALSE, message=FALSE, cache=FALSE}",
-		"opts_knit$set(base.dir='./', fig.path='', out.format='md')",
-		"opts_chunk$set(prompt=TRUE, comment='', results='markup')",
-		"# See yihui.name/knitr/options for more Knitr options.",
-		"##### Put other setup R code here",
-		"",
-		"```",
-		""
-	)
-	for(rmd in mdfiles2) {
-		file <- file(rmd)
-		lines <- readLines(file)
-		close(file)
-		
-		#if the knitsetup block isn't already in the file, then add it
-		suppressWarnings(
-			if(grepl("r knitsetup.+\n", lines)) {
-				lines <- c(knitr.header, lines)
-			}
-		)
-		
-		file <- file(rmd)
-		writeLines(lines, file(rmd))
-		close(file)
-	}
-	
-	setwd(oldwd)
-	invisible()
+  dir = getwd()
+  dir <- normalizePath(dir)
+  checkForGitbook(quiet = TRUE)
+  oldwd <- setwd(dir)
+  test <- system(paste0("gitbook init ", dir))
+  if (test != 0) {
+    stop("gitbook initalization failed")
+  }
+  mdfiles <- list.files(dir, "*.md", recursive = TRUE, full.names = TRUE)
+  mdfiles <- mdfiles[-c(grep("README.md$", mdfiles), grep("SUMMARY.md$", mdfiles))]
+  mdfiles2 <- gsub("\\.md$", ".Rmd", mdfiles)
+  file.rename(mdfiles, mdfiles2)
+  knitr.header <- c("```{r knitsetup, echo=FALSE, results='hide', warning=FALSE, message=FALSE, cache=FALSE}", 
+                  "opts_knit$set(base.dir='./', fig.path='', out.format='md')", 
+                  "opts_chunk$set(prompt=TRUE, comment='', results='markup')", 
+                  "# See yihui.name/knitr/options for more Knitr options.", 
+                  "##### Put other setup R code here", "", "",
+                  "# end setup chunk",
+                  "```")
+
+  for (rmd in mdfiles2) {
+    print(rmd)
+    file <- file(rmd)
+    lines <- readLines(file)
+    close(file)
+  # don't inject knitr setup chunk if Rmd file 
+  # already has one, ie. editing an existing Rmd
+  # or the references Rmd, which has a different setup
+    toMatch <- c("r knitsetup", "r setup")
+    matches <- grepl(paste(toMatch,collapse="|"), lines)  
+    suppressWarnings(if (!any(matches)) {
+      lines <- c(knitr.header, lines)
+    })
+    file <- file(rmd)
+    writeLines(lines, file(rmd))
+   close(file)
+  }
+  setwd(oldwd)
+  invisible()
 }


### PR DESCRIPTION
This removes this error for me:

```
Error in if (grepl("r knitsetup.+\n", lines)) { : 
argument is of length zero
```

Main changes are, first, `mdfiles2 <- gsub("\\.md$", ".Rmd", mdfiles)` using double backslash to escape the period, so we can rename `md` files to `Rmd`, and second, 

```
 toMatch <- c("r knitsetup", "r setup")
 matches <- grepl(paste(toMatch,collapse="|"), lines)  
    suppressWarnings(if (!any(matches)) {
```

So we get just one `TRUE` if there are any matches to either `r knitsetup` or `r setup` anywhere in the file (or a single `FALSE` if there is a match), and we can exclude the `references.Rmd` from this insertion.

Anyway, see if it doesn't break it for you. My details:

```
sessionInfo()
R version 3.0.3 (2014-03-06)
Platform: x86_64-w64-mingw32/x64 (64-bit)

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] knitr_1.5    Rgitbook_0.9

loaded via a namespace (and not attached):
 [1] bibtex_0.3-6        evaluate_0.5.3      formatR_0.10        httr_0.3           
 [5] knitcitations_0.5-0 RCurl_1.95-4.1      rmarkdown_0.1.4     stringr_0.6.2      
 [9] tools_3.0.3         XML_3.98-1.1        xtable_1.7-3  
```
